### PR TITLE
Open task in OSM.org

### DIFF
--- a/client/src/app/task/task-details/task-details.component.html
+++ b/client/src/app/task/task-details/task-details.component.html
@@ -30,5 +30,7 @@
 </div>
 
 <!-- Open in JOSM row -->
-<button (click)="onOpenJosmButtonClicked()">Open in JOSM</button>
-<button (click)="onOpenOsmOrgButtonClicked()">Open in OSM.org</button>
+<div class="open-button-row">
+	<button (click)="onOpenJosmButtonClicked()">Open in JOSM</button>
+	<button (click)="onOpenOsmOrgButtonClicked()" class="open-osm-button">Open in OSM.org</button>
+</div>

--- a/client/src/app/task/task-details/task-details.component.html
+++ b/client/src/app/task/task-details/task-details.component.html
@@ -31,3 +31,4 @@
 
 <!-- Open in JOSM row -->
 <button (click)="onOpenJosmButtonClicked()">Open in JOSM</button>
+<button (click)="onOpenOsmOrgButtonClicked()">Open in OSM.org</button>

--- a/client/src/app/task/task-details/task-details.component.html
+++ b/client/src/app/task/task-details/task-details.component.html
@@ -32,5 +32,5 @@
 <!-- Open in JOSM row -->
 <div class="open-button-row">
 	<button (click)="onOpenJosmButtonClicked()">Open in JOSM</button>
-	<button (click)="onOpenOsmOrgButtonClicked()" class="open-osm-button">Open in OSM.org</button>
+	<button (click)="onOpenOsmOrgButtonClicked()" class="open-osm-button">Open in iD</button>
 </div>

--- a/client/src/app/task/task-details/task-details.component.scss
+++ b/client/src/app/task/task-details/task-details.component.scss
@@ -33,3 +33,11 @@
 .save-button {
 	margin-left: $space-large;
 }
+
+.open-button-row {
+	margin-top: $space-large;
+}
+
+.open-osm-button {
+	margin-left: $space-base;
+}

--- a/client/src/app/task/task-details/task-details.component.ts
+++ b/client/src/app/task/task-details/task-details.component.ts
@@ -110,6 +110,6 @@ export class TaskDetailsComponent extends Unsubscriber implements OnInit {
   }
 
   public onOpenOsmOrgButtonClicked() {
-    this.taskService.openInAnotherTab(this.task)
+    this.taskService.openInOsmOrg(this.task, this.projectId);
   }
 }

--- a/client/src/app/task/task-details/task-details.component.ts
+++ b/client/src/app/task/task-details/task-details.component.ts
@@ -108,4 +108,8 @@ export class TaskDetailsComponent extends Unsubscriber implements OnInit {
           this.notificationService.addError('Unable to open JOSM. Is it running?');
         });
   }
+
+  public onOpenOsmOrgButtonClicked() {
+    this.taskService.openInAnotherTab(this.task)
+  }
 }

--- a/client/src/app/task/task.service.ts
+++ b/client/src/app/task/task.service.ts
@@ -117,9 +117,74 @@ export class TaskService {
       );
   }
 
-  public openInAnotherTab(task: Task) {
+  public openInOsmOrg(task: Task, projectId: string) {
     const e = this.getExtent(task);
-    window.open('https://openstreetmap.org/?bbox=' + e[0] + '%2C' + e[1] + '%2C' + e[2] + '%2C' + e[3], "_blank");
+    const mapView = this.fitExtentToScreen(e, window.screen.availWidth, window.screen.availHeight);
+
+    const comment = encodeURIComponent('#stm #stm-project-' + projectId + ' ');
+    const hashtags = encodeURIComponent('#stm,#stm-project-' + projectId);
+
+    window.open('https://openstreetmap.org/edit?editor=id#map=' + mapView.zoom + '/' + mapView.centerLat + '/' + mapView.centerLon + '&comment=' + comment + '&hashtags=' + hashtags);
+  }
+
+  /**
+   * Calculates the center of the map as well as the zoom-level so that the given bounding box fits into the map view. The zoom-level is the
+   * XYZ specific Z value (so something between 1 and 20).
+   *
+   * @param bounds The bounding box of the part of the world to look at. This must have the array value format [E, N, W, S].
+   * @param mapWidth The width of the screen/map.
+   * @param mapHeight The height of the screen/map.
+   */
+  public fitExtentToScreen(bounds: Extent, mapWidth: number, mapHeight: number): { centerLat: number, centerLon: number, zoom: number } {
+    if (bounds == null || bounds.length < 4) {
+      return {
+        centerLat: 0,
+        centerLon: 0,
+        zoom: 1
+      };
+    }
+
+    // Padding around bounding-box in map in pixels
+    const padding = 20;
+
+    // Size of each tile in pixels
+    const tileSize = 256;
+
+    let boundsDeltaX: number;
+    let centerLat: number;
+    let centerLon: number;
+
+    // Check if east value is greater than west value which would indicate that bounding box crosses the antimeridian.
+    if (bounds[2] > bounds[0]) {
+      boundsDeltaX = bounds[2] - bounds[0];
+      centerLon = (bounds[2] + bounds[0]) / 2;
+    } else {
+      boundsDeltaX = 360 - (bounds[0] - bounds[2]);
+      centerLon = ((bounds[2] + bounds[0]) / 2 + 360) % 360 - 180;
+    }
+
+    const ry1 = Math.log((Math.sin(bounds[1] * Math.PI / 180) + 1) / Math.cos(bounds[1] * Math.PI / 180));
+    const ry2 = Math.log((Math.sin(bounds[3] * Math.PI / 180) + 1) / Math.cos(bounds[3] * Math.PI / 180));
+    const ryc = (ry1 + ry2) / 2;
+
+    centerLat = Math.atan(Math.sinh(ryc)) * 180 / Math.PI;
+
+    const resolutionHorizontal = boundsDeltaX / (mapWidth - padding * 2);
+
+    const vy0 = Math.log(Math.tan(Math.PI * (0.25 + centerLat / 360)));
+    const vy1 = Math.log(Math.tan(Math.PI * (0.25 + bounds[3] / 360)));
+    const zoomFactorPowered = (mapHeight * 0.5 - padding) / (40.7436654315252 * (vy1 - vy0));
+    const resolutionVertical = 360.0 / (zoomFactorPowered * tileSize);
+
+    const resolution = Math.max(resolutionHorizontal, resolutionVertical);
+
+    const zoom = Math.log2(360 / (resolution * tileSize));
+
+    return {
+      centerLon,
+      centerLat,
+      zoom
+    };
   }
 
   public getExtent(task: Task): Extent {

--- a/client/src/app/task/task.service.ts
+++ b/client/src/app/task/task.service.ts
@@ -117,6 +117,11 @@ export class TaskService {
       );
   }
 
+  public openInAnotherTab(task: Task) {
+    const e = this.getExtent(task);
+    window.open('https://openstreetmap.org/?bbox=' + e[0] + '%2C' + e[1] + '%2C' + e[2] + '%2C' + e[3], "_blank");
+  }
+
   public getExtent(task: Task): Extent {
     return task.geometry.getGeometry().getExtent();
   }


### PR DESCRIPTION
Allow user to open task extent on openstreetmap.org site in another tab or window on browser.
This will help users to work with iD editor,  or another favorite editors in addition to JOSM. 

Implement #87 

Signed-off-by: Hiroshi Miura <miurahr@linux.com>