### PR TITLE
server: README: express db pass/user

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -34,6 +34,13 @@ The frameworks/libraries this project uses are there in order to make the develo
 The server requires a database called `stm` with the required tables as described below.
 This description assumes that you use docker instead of an direct installation of PostgreSQL.
 
+### Set Database user/pass as environment variable
+
+* `export STM_DB_USERNAME=postgres STM_DB_PASSWORD=geheim`
+
+If you want to run test expressed below, user and pass should be as same as the above.
+If you want to run it as public site, you should change to your own unique one.
+
 ### Start as docker container
 
 **tl;dr:**


### PR DESCRIPTION
server/README.md lacks descrition of postgresql db's username and password.

It is hard-coded in server test script, so I've put it as a note.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>