### PR TITLE
client : Add french translation

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -18,7 +18,8 @@
         "locales": {
           "ja": "src/locale/messages.ja.xlf",
           "de": "src/locale/messages.de.xlf",
-          "zh-CN": "src/locale/messages.zh-CN.xlf"
+          "zh-CN": "src/locale/messages.zh-CN.xlf",
+          "fr": "src/locale/messages.fr.xlf"
         }
       },
       "architect": {
@@ -72,6 +73,11 @@
             "zh-CN": {
               "localize": [
                 "zh-CN"
+              ]
+            },
+            "fr": {
+              "localize": [
+                "fr"
               ]
             },
             "production": {
@@ -155,6 +161,9 @@
             },
             "zh-CN": {
               "browserTarget": "simple-task-manager:build:zh-CN"
+            },
+            "fr-FR": {
+              "browserTarget": "simple-task-manager:build:fr-FR"
             }
           }
         },

--- a/client/nginx-test.conf
+++ b/client/nginx-test.conf
@@ -15,7 +15,7 @@ server {
 	ssl_certificate /etc/letsencrypt/live/stm-test.hauke-stieler.de/cert.pem;
 	ssl_certificate_key /etc/letsencrypt/live/stm-test.hauke-stieler.de/privkey.pem;
 
-	location ~ ^/(en-US|ja|de|zh-CN)/ {
+	location ~ ^/(en-US|ja|de|zh-CN|fr)/ {
 		root   /usr/share/nginx/html;
 		index  index.html;
 		try_files $uri$args $uri$args/ /$1/index.html;

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -15,7 +15,7 @@ server {
 	ssl_certificate /etc/letsencrypt/live/stm.hauke-stieler.de/cert.pem;
 	ssl_certificate_key /etc/letsencrypt/live/stm.hauke-stieler.de/privkey.pem;
 
-	location ~ ^/(en-US|ja|de|zh-CN)/ {
+	location ~ ^/(en-US|ja|de|zh-CN|fr)/ {
 		root   /usr/share/nginx/html;
 		index  index.html;
 		try_files $uri$args $uri$args/ /$1/index.html;

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "dev-ja": "ng serve --watch --configuration=ja",
     "dev-de": "ng serve --watch --configuration=de",
     "dev-zh": "ng serve --watch --configuration=zh-CN",
+    "dev-fr": "ng serve --watch --configuration=fr",
     "dev-local": "ng serve --watch -c local",
     "build": "ng build --localize",
     "build-prod": "ng build --prod --localize",

--- a/client/src/app/common/selected-language.service.ts
+++ b/client/src/app/common/selected-language.service.ts
@@ -28,6 +28,7 @@ export class SelectedLanguageService {
       new Language('de', 'Deutsch'),
       new Language('ja', '日本語'),
       new Language('zh-CN', '中文'),
+      new Language('fr', 'Français'),
     ];
   }
 

--- a/client/src/locale/messages.fr.xlf
+++ b/client/src/locale/messages.fr.xlf
@@ -1,0 +1,972 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en-US" datatype="plaintext" original="ng2.template" target-language="fr">
+    <body>
+      <trans-unit id="b12abc47005741b160538ec891a6915beadde39e" datatype="html">
+        <source>Welcome <x id="INTERPOLATION" equiv-text="{{userName}}"/> :)</source>
+        <target state="translated">Bienvenue <x id="INTERPOLATION" equiv-text="{{userName}}"/> :)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/manager/manager.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="03ddc67567196cbe377d641f7c8e797af36e4bb1" datatype="html">
+        <source>Language selection:</source>
+        <target state="translated">Langue :</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/manager/manager.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="bb694b49d408265c91c62799c2b3a7e3151c824d" datatype="html">
+        <source>Logout</source>
+        <target state="translated">Déconnexion</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/manager/manager.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">logout button</note>
+      </trans-unit>
+      <trans-unit id="a40a5da1275dd0b1cba2d4eb75b3c874db4a8858" datatype="html">
+        <source>
+			Welcome to the SimpleTaskManager for <x id="START_LINK" ctype="x-a" equiv-text="&lt;a>"/>OpenStreetMap<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>
+		</source>
+        <target state="translated">
+			Bienvenue sur SimpleTaskManager pour <x id="START_LINK" ctype="x-a" equiv-text="&lt;a>"/>OpenStreetMap<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>
+		</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/auth/login/login.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6765b4c916060f6bc42d9bb69e80377dbcb5e4e9" datatype="html">
+        <source>Login</source>
+        <target state="translated">Connexion</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/auth/login/login.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="LOGIN_CHANGELOG" datatype="html">
+        <source>
+          <x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p>"/><x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b>"/>Changes in 1.2.0:<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b>"/><x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p>"/>
+          New features:
+          <x id="START_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;ul>"/>
+              <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>New project creation:<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+              <x id="START_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;ul>"/>
+                  <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>Toolbar<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+                  <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>Give own names to tasks<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+                  <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>Preview for subdividing tasks<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+                  <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>More formats for importing tasks<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+                  <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>Overall better handling of interactions<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+              <x id="CLOSE_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;/ul>"/>
+          <x id="CLOSE_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;/ul>"/>
+          Bug fixes:
+          <x id="START_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;ul>"/>
+              <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>Better error handling when importing tasks<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+          <x id="CLOSE_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;/ul>"/>
+          Minor changes:
+          <x id="START_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;ul>"/>
+              <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>Save map location to local storage<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+              <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>Different and better visible color scheme for tasks on the map<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+          <x id="CLOSE_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;/ul>"/>
+          Internals:
+          <x id="START_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;ul>"/>
+              <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>Distinct DTO classes for project creation<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+          <x id="CLOSE_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;/ul>"/>
+        </source>
+        <target state="translated">
+          <x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p>"/><x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b>"/>Changements en 1.2.0:<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b>"/><x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p>"/>
+          Nouvelles fonctionnalités :
+          <x id="START_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;ul>"/>
+              <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>Création de nouveau projet :<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+              <x id="START_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;ul>"/>
+                  <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>Barre d'outil<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+                  <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>Nommage individuel des tâches<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+                  <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>Prévisualisation de la subdivision des tâches<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+                  <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>Plus de formats d'import des tâches<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+                  <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>Améliorations globales de l'interactivité<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+              <x id="CLOSE_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;/ul>"/>
+          <x id="CLOSE_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;/ul>"/>
+          Correction de bugs :
+          <x id="START_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;ul>"/>
+              <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>Meilleur gestion des erreurs lors de l'import de tâches<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+          <x id="CLOSE_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;/ul>"/>
+          Changements mineurs :
+          <x id="START_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;ul>"/>
+              <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>Sauvegarde de la position de la carte dans le stockage local<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+              <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>Meilleure palette de couleurs pour le rendu des tâches sur la carte<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+          <x id="CLOSE_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;/ul>"/>
+          En interne :
+          <x id="START_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;ul>"/>
+              <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li>"/>Utilisation de classes DTO distinctes pour la création de projets<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li>"/>
+          <x id="CLOSE_UNORDERED_LIST" ctype="x-ul" equiv-text="&lt;/ul>"/>
+        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/auth/login/login.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1a6adc5f5c4e0ee07c9edbbdb843d417930db480" datatype="html">
+        <source>Succesfully logged in :)</source>
+        <target state="translated">Connexion réussie :)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/auth/oauth-landing/oauth-landing.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="d2a7deb7096cada2c3177157652680fe7e6de0ed" datatype="html">
+        <source>Projects</source>
+        <target state="translated">Projets</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project-list/project-list.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="29d7d978a0fc305f377415641b05669ca55b1a81" datatype="html">
+        <source>You currently don't have any projects.</source>
+        <target state="translated">Vous n'avez actuellement aucun projet.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project-list/project-list.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ecfa915d62703fa0b8e5787e988f8f379057965b" datatype="html">
+        <source>Create project</source>
+        <target state="translated">Créer un projet</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project-list/project-list.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="05e16b88c8826cf9aae20fd255f4b6088aadfa2b" datatype="html">
+        <source>* you own this project</source>
+        <target state="translated">* vous êtes propriétaire de ce projet</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project-list/project-list.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="553204f35cd5b8f9d341963cf371cc0439a9fb0a" datatype="html">
+        <source>&lt; Back</source>
+        <target state="translated">&lt; Retour</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project/project.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Back button</note>
+      </trans-unit>
+      <trans-unit id="4a22c6843133f0b0d7dc0d28f864f2f90c1de7ad" datatype="html">
+        <source>Description:</source>
+        <target state="translated">Description :</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project/project.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project-settings/project-settings.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/project-properties/project-properties.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <note priority="1" from="description">Description label</note>
+      </trans-unit>
+      <trans-unit id="4d13a9cd5ed3dcee0eab22cb25198d43886942be" datatype="html">
+        <source>Users</source>
+        <target state="translated">Utilisateurs</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project/project.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="121cc5391cd2a5115bc2b3160379ee5b36cd7716" datatype="html">
+        <source>Settings</source>
+        <target state="translated">Paramètres</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project/project.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="586a5fd72602b5b14ec0c55f84814de47bb21e3a" datatype="html">
+        <source>Tasks</source>
+        <target state="translated">Tâches</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/task/task-list/task-list.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8dd413cee2228118c536f503709329a4d1a395e2" datatype="html">
+        <source>Done</source>
+        <target state="translated">Terminé</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/task/task-list/task-list.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/task/task-details/task-details.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="bc545564a19ac8305bff6a4c3f2d0810792b08c4" datatype="html">
+        <source>(you)</source>
+        <target state="translated">(vous)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/task/task-list/task-list.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="9c95e79714babddbf9f35af7a271f780e6d7589d" datatype="html">
+        <source>Assign to me</source>
+        <target state="translated">Me l'assigner</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/task/task-details/task-details.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="f85227c27f93b61f68a6fe14f9d95abf2f5be8bf" datatype="html">
+        <source>Assigned to: <x id="INTERPOLATION" equiv-text="{{assignedUserName}}"/></source>
+        <target state="translated">Assigé à : <x id="INTERPOLATION" equiv-text="{{assignedUserName}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/task/task-details/task-details.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="06eaf93a4e6dc114741c8e642a4e57026da436bf" datatype="html">
+        <source>Unassign</source>
+        <target state="translated">Libérer</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/task/task-details/task-details.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="bdf3934d1c216adf8018d30e13bb396eb4d0ab89" datatype="html">
+        <source>Points:</source>
+        <target state="translated">Points :</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/task/task-details/task-details.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/task/task-details/task-details.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="52c9a103b812f258bcddc3d90a6e3f46871d25fe" datatype="html">
+        <source>Save</source>
+        <target state="translated">Enregistrer</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/task/task-details/task-details.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project-settings/project-settings.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="0728be2cde8178df6f108a5e2fc0b4ff39492396" datatype="html">
+        <source>Open in JOSM</source>
+        <target state="translated">Ouvrir dans JOSM</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/task/task-details/task-details.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4ded01fb65e9e8ffb0cca5b798e24e77eedd9d4d" datatype="html">
+        <source>Open in iD</source>
+        <target state="translated">Ouvrir dans iD</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/task/task-details/task-details.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ab3e799adeb088d5437f0bb15e321ba9c1c7ff58" datatype="html">
+        <source>
+  Version: <x id="START_LINK" ctype="x-a" equiv-text="&lt;a>"/><x id="INTERPOLATION" equiv-text="{{version}}"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>Code: <x id="START_LINK_1" ctype="x-a" equiv-text="&lt;a>"/>GitHub<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>License: <x id="START_LINK_2" ctype="x-a" equiv-text="&lt;a>"/>GPLv3<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>Icons: <x id="START_LINK_3" ctype="x-a" equiv-text="&lt;a>"/>Linearicons<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>
+</source>
+        <target state="translated">
+  Version : <x id="START_LINK" ctype="x-a" equiv-text="&lt;a>"/><x id="INTERPOLATION" equiv-text="{{version}}"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>Code : <x id="START_LINK_1" ctype="x-a" equiv-text="&lt;a>"/>GitHub<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>Licence : <x id="START_LINK_2" ctype="x-a" equiv-text="&lt;a>"/>GPLv3<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>Icônes : <x id="START_LINK_3" ctype="x-a" equiv-text="&lt;a>"/>Linearicons<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>
+</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ui/footer/footer.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5c5cd4f8e377c2f2bad0d4e26e401f83d777dbfc" datatype="html">
+        <source>&lt; Cancel</source>
+        <target state="translated">&lt; Annuler</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/project-creation/project-creation.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="887d180afd5c79d3d6b4b5d2877dba5babf933d9" datatype="html">
+        <source>
+			Save
+		</source>
+        <target state="translated">
+			Enregistrer
+		</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/project-creation/project-creation.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="647cbc795a270aec8cc5703618774909673b0b78" datatype="html">
+        <source>Properties:</source>
+        <target state="translated">Propriétés :</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/project-creation/project-creation.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/project-creation/project-creation.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project-settings/project-settings.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ed9b07e91b831a27867345b0555adb38712cfff3" datatype="html">
+        <source>Tasks:</source>
+        <target state="translated">Tâches :</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/project-creation/project-creation.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1ce4ea38f6f8dd51a865b801914b8e75e43cf2bc" datatype="html">
+        <source>Subdivide:</source>
+        <target state="translated">Subdiviser :</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/project-creation/project-creation.component.html</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3d243a75c1a16642d9d887827bdaa8e97a8e6e5c" datatype="html">
+        <source>Invite</source>
+        <target state="translated">Inviter</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/user/user-invitation/user-invitation.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="d9d8be77cf88cf6bfb0cd5bdfdd3290c58380422" datatype="html">
+        <source>Delete Project</source>
+        <target state="translated">Supprimer le projet</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project-settings/project-settings.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="0b6e28c46583c66b375fc6c106c796e3da679ebc" datatype="html">
+        <source>Really delete Project?</source>
+        <target state="translated">Vraiment supprimer le projet ?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project-settings/project-settings.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3d3ae7deebc5949b0c1c78b9847886a94321d9fd" datatype="html">
+        <source>No</source>
+        <target state="translated">Non</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project-settings/project-settings.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project-settings/project-settings.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4f20f2d5a6882190892e58b85f6ccbedfa737952" datatype="html">
+        <source>Yes</source>
+        <target state="translated">Oui</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project-settings/project-settings.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project-settings/project-settings.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ed743d561e1c525c5a374d0b20d07d3d4fdfc106" datatype="html">
+        <source>Leave project</source>
+        <target state="translated">Quitter le projet</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project-settings/project-settings.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="b73fb12e84404d1c8858445f634bc5caf53b8b41" datatype="html">
+        <source>Really leave Project?</source>
+        <target state="translated">Vraiment quitter le projet ?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project-settings/project-settings.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="616e206cb4f25bd5885fc35925365e43cf5fb929" datatype="html">
+        <source>Name:</source>
+        <target state="translated">Nom :</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project/project-settings/project-settings.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/project-properties/project-properties.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/task-edit/task-edit.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6d5f426f02915905607a0e40b46ca25e89f9ac90" datatype="html">
+        <source>Loading ...</source>
+        <target state="translated">Chargement ...</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ui/notification/notification.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="e007257a442d4f8c92941a3de92bf72ed1a438c8" datatype="html">
+        <source>ERROR:</source>
+        <target state="translated">ERREUR :</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ui/notification/notification.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ui/notification/notification.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5372b97b027c5e06c157f70e930ac7a5b1db2355" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="{{ remainingErrors }}"/>
+			errors left</source>
+        <target state="translated"><x id="INTERPOLATION" equiv-text="{{ remainingErrors }}"/>
+			erreurs restantes</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ui/notification/notification.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7e6c975ebea8b5f8b120905ca7acf9f8edf59d8e" datatype="html">
+        <source>OK</source>
+        <target state="translated">OK</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ui/notification/notification.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ui/notification/notification.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ui/notification/notification.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="bb563263feeb05f7a58f13e0160513d5dc7cdc39" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="{{ remainingWarning }}"/>
+			warnings left</source>
+        <target state="translated"><x id="INTERPOLATION" equiv-text="{{ remainingWarning }}"/>
+			avertissements restants</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ui/notification/notification.component.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7627c8c61fbdc91eef42ecf3fd70e650318e8ce7" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="{{ remainingInfo }}"/>
+			notifications left</source>
+        <target state="translated"><x id="INTERPOLATION" equiv-text="{{ remainingInfo }}"/>
+			notifications restantes</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ui/notification/notification.component.html</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ae9555ed661c4fc9adf8c6ec71e39c67f05513fe" datatype="html">
+        <source>This divides the selected task into smaller tasks of the selected shape and size.</source>
+        <target state="translated">Divise la tâche selectionnée en plus petites tâches de la forme et taille sélectionnée.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-divide/shape-divide.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="44408118c125445318294c7a1ec080166993294c" datatype="html">
+        <source>Task selected </source>
+        <target state="translated">Tâche sélectionnée </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-divide/shape-divide.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4d8c72b8aa088152b8fe08fb52e7668731501ed5" datatype="html">
+        <source>Click on the map to select a task.</source>
+        <target state="translated">Cliquer sur la carte pour sélectionner une tâche.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-divide/shape-divide.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1c1d1f8a90a0d951c07eff3863b48ab97377d8a4" datatype="html">
+        <source>Shape size:</source>
+        <target state="translated">Taille de la forme :</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-divide/shape-divide.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7886c0ba80624ae271468582a0ea743cc157fa2e" datatype="html">
+        <source>meters</source>
+        <target state="translated">mètres</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-divide/shape-divide.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1f672a38e8b9e8fc29a0ce0a4f926c00e8da15a3" datatype="html">
+        <source>Shape:</source>
+        <target state="translated">Forme :</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-divide/shape-divide.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6e644e34744b7ab4dae805ec4fb40a7fa50c8cb5" datatype="html">
+        <source>square</source>
+        <target state="translated">carré</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-divide/shape-divide.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="99dafbec7a39a738b6672303e7dacc04cd343352" datatype="html">
+        <source>hexagon</source>
+        <target state="translated">hexagone</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-divide/shape-divide.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="579b21eef0e6bdd79af799ade0059691149f324e" datatype="html">
+        <source>triangle</source>
+        <target state="translated">triangle</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-divide/shape-divide.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3e2a583f531f7dd9f089f68a6968e444c372c3e8" datatype="html">
+        <source>Preview</source>
+        <target state="translated">Prévisualiser</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-divide/shape-divide.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="64da6b784c67223a7ce9517cbd42c453e652df2a" datatype="html">
+        <source>Divide</source>
+        <target state="translated">Diviser</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-divide/shape-divide.component.html</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1c222c958cc86240c7e3e7f38ce8c730fda6f17f" datatype="html">
+        <source>Upload a GeoJSON, OSM-XML, GPX, EsriJson, KML or WKT file, which contains polygons. Each polygon will result in a single task.</source>
+        <target state="translated">Téléverser un fichier GeoJSON, OSM-XML, GPX, EsriJson, KML ou WKT contenant des polygones. Chaque polygone deviendra une tâche.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-upload/shape-upload.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="30425abcb2ca17bc7f74857afd2d4a74e31b9b2b" datatype="html">
+        <source>Upload file</source>
+        <target state="translated">Téléverser un fichier</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-upload/shape-upload.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="d8ef47c8eceb33c1cef17101c49af48ce53295f8" datatype="html">
+        <source>URL to GeoJSON, OSM-XML, GPX, EsriJson, KML or WKT data:</source>
+        <target state="translated">URL vers les données GeoJSON, OSM-XML, GPX, EsriJson, KML ou WKT :</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-remote/shape-remote.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8d7fb36ea2bff6fd8a53c1676d45e63ab624ad16" datatype="html">
+        <source>Load</source>
+        <target state="translated">Charger</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-remote/shape-remote.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="fa89153d30285e65b4d70bd5682f2d4f4ad5bc0a" datatype="html">
+        <source>Loading data from Overpass:</source>
+        <target state="translated">Chargement de données depuis Overpass :</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-remote/shape-remote.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="bfdb093a9e1328895ad703094e1ad85ca530ce30" datatype="html">
+        <source>Create your query</source>
+        <target state="translated">Créer votre requête</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-remote/shape-remote.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">loading data from overpass</note>
+      </trans-unit>
+      <trans-unit id="622e64f6296a7467dd7da977bee29f2dc726fdea" datatype="html">
+        <source>Click on "Export"</source>
+        <target state="translated">Cliquer sur "Exporter"</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-remote/shape-remote.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">loading data from overpass</note>
+      </trans-unit>
+      <trans-unit id="485a698b86f89dca935c8d6c92f695e6ae0c93c8" datatype="html">
+        <source>Copy the link after "raw data directly from" (right click and "copy link")</source>
+        <target state="translated">Copier le lien après "données brutes depuis" (clic-droit et "Copier l'adresse du lien")</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-remote/shape-remote.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">loading data from overpass</note>
+      </trans-unit>
+      <trans-unit id="bb8915a54f561863ae3d67bfb1593724ca320c8e" datatype="html">
+        <source>Paste this URL in here</source>
+        <target state="translated">Coller l'URL ici</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/shape-remote/shape-remote.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">loading data from overpass</note>
+      </trans-unit>
+      <trans-unit id="WARN_AUTH_FAIL" datatype="html">
+        <source>Logout because authorization was not successful</source>
+        <target state="translated">Échec d'authentification, déconnexion</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ERROR_NOT_CREATE_PROJ" datatype="html">
+        <source>Could not create project</source>
+        <target state="translated">Impossible de créer le projet</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ERROR_LOAD_PROJECTS" datatype="html">
+        <source>Could not load projects</source>
+        <target state="translated">Impossible de charger les projets</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ERROR_LIVE_UPDATE" datatype="html">
+        <source>Could not initialize live-updates</source>
+        <target state="translated">Impossible d'initialiser les mises à jour en temps réel</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ERROR_COULD_NOT_UPLOAD" datatype="html">
+        <source>Could not upload file '<x id="INTERPOLATION" equiv-text="{{interp}}"/>'</source>
+        <target state="translated">Impossible de téléverser le fichier '<x id="INTERPOLATION" equiv-text="{{interp}}"/>'</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ERROR_OVERPASS_NO_POLYGONS" datatype="html">
+        <source>No usable polygons have been found. Make sure the output format is set to 'out:xml' and the result contains actual polygons.</source>
+        <target state="translated">Aucun polygone utilisable n'a été trouvé. Vérifier que le format de sortie est bien 'out:xml' et que le résultat contient bien des polygones.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ERROR_UNABLE_LOAD_URL" datatype="html">
+        <source>Unable to load data from remote URL</source>
+        <target state="translated">Impossible de charger les données depuis l'URL</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="WARN_ALREADY_MEMBER" datatype="html">
+        <source>User '<x id="INTERPOLATION" equiv-text="{{interp}}"/>' is already a member of this project</source>
+        <target state="translated">L'utilisateur '<x id="INTERPOLATION" equiv-text="{{interp}}"/>' est déjà membre de ce projet</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ERROR_USER_ID" datatype="html">
+        <source>Could not load user ID for user '<x id="INTERPOLATION" equiv-text="{{interp}}"/>'</source>
+        <target state="translated">Impossible de charger l'ID de l'utilisateur '<x id="INTERPOLATION" equiv-text="{{interp}}"/>'</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ERROR_UNABLE_LOAD_USER" datatype="html">
+        <source>Unable to load assigned user</source>
+        <target state="translated">Impossible de charger l'utilisateur assigné</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ERROR_ASSIGN_USER" datatype="html">
+        <source>Could not assign user</source>
+        <target state="translated">Impossible d'assigner à l'utilisateur</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ERROR_UNASSIGN_USER" datatype="html">
+        <source>Could not unassign user</source>
+        <target state="translated">Impossible de libérer l'utilisateur</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ERROR_PROCESS_POINTS" datatype="html">
+        <source>Could not set process points</source>
+        <target state="translated">Impossible de définir les points de traitement</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ERROR_OPEN_JOSM" datatype="html">
+        <source>Unable to open JOSM. Is it running?</source>
+        <target state="translated">Impossible d'ouvrir JOSM. Est-il lancé?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ERROR_NOT_LOAD_PROJ" datatype="html">
+        <source>Could not load project '<x id="INTERPOLATION" equiv-text="{{interp}}"/>'</source>
+        <target state="translated">Impossible de charger le projet '<x id="INTERPOLATION" equiv-text="{{interp}}"/>'</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ERROR_ONT_DELETE_PROJ" datatype="html">
+        <source>Could not delete project</source>
+        <target state="translated">Impossible de supprimer le projet</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="INFO_REMOVED_PROJ" datatype="html">
+        <source>Project removed successfully</source>
+        <target state="translated">Projet supprimé</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ERROR_LEAVE_PROJ" datatype="html">
+        <source>Could not leave project</source>
+        <target state="translated">Impossible de quitter le projet</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="INFO_SUCCESS_UPDATE_PROJ" datatype="html">
+        <source>Successfully updated project</source>
+        <target state="translated">Projet mis à jour</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ERROR_UPDATE_PROJ_TITLE" datatype="html">
+        <source>Unable to update project title and/or description</source>
+        <target state="translated">Impossible de mettre à jour le titre et/ou la description</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="WARN_PROJECT_REMOVED" datatype="html">
+        <source>The project '<x id="INTERPOLATION" equiv-text="{{interp}}"/>' has been removed</source>
+        <target state="translated">Le projet '<x id="INTERPOLATION" equiv-text="{{interp}}"/>' a été supprimé</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="WARN_REMOVED_USER_PROJECT" datatype="html">
+        <source>You have been removed from project '<x id="INTERPOLATION" equiv-text="{{interp}}"/>'</source>
+        <target state="translated">Vous avez été supprimé du projet '<x id="INTERPOLATION" equiv-text="{{interp}}"/>'</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ERROR_NOT_REMOVE_USER" datatype="html">
+        <source>Could not remove user</source>
+        <target state="translated">Impossible de supprimer l'utilisateur</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ERROR_NOT_INVITE_USER" datatype="html">
+        <source>Could not invite user<x id="INTERPOLATION" equiv-text="{{interp}}"/></source>
+        <target state="translated">Impossible d'inviter l'utilisateur <x id="INTERPOLATION" equiv-text="{{interp}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TABS_TASKS" datatype="html">
+        <source>Tasks</source>
+        <target state="translated">Tâches</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TABS_USERS" datatype="html">
+        <source>Users</source>
+        <target state="translated">Utilisateurs</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TABS_SETTINGS" datatype="html">
+        <source>Settings</source>
+        <target state="translated">Paramètres</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TABS_UPLOAD" datatype="html">
+        <source>Upload</source>
+        <target state="translated">Téléversement</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TABS_REMOTE" datatype="html">
+        <source>Remote</source>
+        <target state="translated">Distant</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TABS_PROPERTIES" datatype="html">
+        <source>Properties</source>
+        <target state="translated">Propriétés</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TASK_MAP_DONE" datatype="html">
+        <source>DONE</source>
+        <target state="translated">TERMINÉ</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="TASK_YOU" datatype="html">
+        <source>you</source>
+        <target state="translated">vous</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/translation-extraction.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="e28ee80cd3a124e109793180dfd1f8d8067dcc6b" datatype="html">
+        <source>Zoom in</source>
+        <target state="translated">Zoomer</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/drawing-toolbar/drawing-toolbar.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="a3dfc58748f790fa096cf3c5fc331f90846e1772" datatype="html">
+        <source>Zoom out</source>
+        <target state="translated">Dézoomer</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/drawing-toolbar/drawing-toolbar.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4f5724e5ad8f6385d335b6705c780eae7110ec70" datatype="html">
+        <source>Draw new polygon</source>
+        <target state="translated">Dessiner un nouveau polygone</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/drawing-toolbar/drawing-toolbar.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="46205b8c134572eadf2daeea8c8dce5974a32216" datatype="html">
+        <source>Edit polygon</source>
+        <target state="translated">Éditer polygone</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/drawing-toolbar/drawing-toolbar.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="07719975214d77aa88d781887c00cd217dec8be8" datatype="html">
+        <source>Remove polygon</source>
+        <target state="translated">Supprimer polygone</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/drawing-toolbar/drawing-toolbar.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="628b295733edba52d46466df62992b41b162a162" datatype="html">
+        <source>There are no tasks here yet. Use the pencil-tool to draw tasks or import tasks via the "Upload" or "Remote" tab.</source>
+        <target state="translated">Il n'y a pas encore de tâche ici. Utiliser l'outil crayon pour dessiner des tâches, ou importer des tâches via les onglets "Téléversement" ou "Distant".</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/task-draft-list/task-draft-list.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="d46dcf6ff2f4a17168e3bdb14102b9ba787ba741" datatype="html">
+        <source>Max. points per task:</source>
+        <target state="translated">Max. de points par tâche :</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/project-creation/project-properties/project-properties.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
As mentionned in https://github.com/hauke96/simple-task-manager/issues/121
I ran `npm run build-prod` successfully and `fr` static content was successfully generated.

Translation file generated with poedit + manual fixes to tabs/spaces in order to match the origin strings.
Please tell me if this is ok, I don't know much about the node and angular things.

Thank you